### PR TITLE
Fix: L'intégration ne semble plus fonctionner en janvier.

### DIFF
--- a/custom_components/veolia/coordinator.py
+++ b/custom_components/veolia/coordinator.py
@@ -62,7 +62,7 @@ class VeoliaDataUpdateCoordinator(DataUpdateCoordinator):
             else:
                 # Regular fetch
                 LOGGER.debug("Periodic fetch - 2 months")
-                if (now.month > 1):
+                if now.month > 1:
                     start_date = date(now.year, now.month - 1, 1)
                 else:
                     start_date = date(now.year - 1, 12, 1)


### PR DESCRIPTION
Check that month is >1 when retrieving past two months of data, otherwise decrement year instead