### PR TITLE
Revert PR#101 + gestion des REDIRIGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
 > ### UNIQUEMENT compatible avec le nouveau site de Veolia : https://www.eau.veolia.fr/
 >
 > ### N'est PAS compatible avec les sous domaines suivant : https://service.eau.veolia.fr & https://espace-client.vedif.eau.veolia.fr
+>
+> ### Vérifiez la compatibilité de votre commune : https://prd-ael-sirius-refcommunes.istefr.fr/communes-nationales?q=VOTRE_CODE_POSTAL
+> Les communes de type `NON_REDIRIGE` et `REDIRIGE` sont supportées (ex : https://eaudetm.monespace.eau.veolia.fr).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 >
 > Merci d’avance pour votre aide et votre engagement ! 💙
 
-> ### Portails compatibles : voir [PORTALS.md](https://github.com/Jezza34000/veolia-api/blob/main/PORTALS.md)
+> ### UNIQUEMENT compatible avec le nouveau site de Veolia : https://www.eau.veolia.fr/
 >
-> ### N'est PAS compatible avec : https://service.eau.veolia.fr & https://espace-client.vedif.eau.veolia.fr
+> ### N'est PAS compatible avec les sous domaines suivant : https://service.eau.veolia.fr & https://espace-client.vedif.eau.veolia.fr
 
 ---
 
@@ -100,32 +100,6 @@ Pour ajouter la carte de consommation d'eau journalière, sur votre dashboard, c
 <a href=""><img src="https://raw.githubusercontent.com/Jezza34000/homeassistant_veolia/main/images/config_carte.png"></a>
 
 > #### **Note :** La carte Graphique des statistiques ne fonctionnera qu'avec le sensor `sensor.veolia_consommation_journaliere`
-
-## Vérifier l'éligibilité de votre commune
-
-Avant d'installer l'intégration, vous pouvez vérifier si votre commune est prise en charge en interrogeant l'API Veolia depuis votre navigateur ou avec `curl` :
-
-```
-https://prd-ael-sirius-refcommunes.istefr.fr/communes-nationales?q=VOTRE_CODE_POSTAL
-```
-
-Dans le résultat JSON, cherchez votre commune et examinez le champ `type_commune` :
-
-| Valeur `type_commune`         | Éligibilité                                  |
-| ----------------------------- | -------------------------------------------- |
-| `NON_REDIRIGE`                | ✅ Compatible — portail `eau.veolia.fr`      |
-| `REDIRIGE` (hostname connu)   | ✅ Compatible — portail alternatif supporté  |
-| `REDIRIGE` (hostname inconnu) | ❌ Non supporté — portail non encore intégré |
-| `NON_DESSERVIE`               | ❌ Veolia ne dessert pas cette commune       |
-
-# Portails Veolia supportés (04/2026)
-
-| Hostname                          | Description               |
-| --------------------------------- | ------------------------- |
-| `eau.veolia.fr`                   | Veolia France (national)  |
-| `eaudetm.monespace.eau.veolia.fr` | Eau de Toulouse Métropole |
-
-Votre portail n'est pas géré? Voir [CONTRIBUTING.md](https://github.com/Jezza34000/veolia-api/blob/main/CONTRIBUTING.md#adding-a-portal)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 > ### N'est PAS compatible avec les sous domaines suivant : https://service.eau.veolia.fr & https://espace-client.vedif.eau.veolia.fr
 >
 > ### Vérifiez la compatibilité de votre commune : https://prd-ael-sirius-refcommunes.istefr.fr/communes-nationales?q=VOTRE_CODE_POSTAL
+>
 > Les communes de type `NON_REDIRIGE` et `REDIRIGE` sont supportées (ex : https://eaudetm.monespace.eau.veolia.fr).
 
 ---

--- a/custom_components/veolia/config_flow.py
+++ b/custom_components/veolia/config_flow.py
@@ -2,7 +2,7 @@
 
 import aiohttp
 from veolia_api import VeoliaAPI
-from veolia_api.exceptions import VeoliaAPIInvalidCredentialsError
+from veolia_api.exceptions import VeoliaAPIInvalidCredentialsError, VeoliaAPITokenError
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -96,7 +96,7 @@ class VeoliaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         title=user_input[CONF_USERNAME],
                         data=user_input,
                     )
-            except VeoliaAPIInvalidCredentialsError:
+            except (VeoliaAPIInvalidCredentialsError, VeoliaAPITokenError):
                 self._errors["base"] = "invalid_credentials"
             except Exception:  # noqa: BLE001
                 LOGGER.debug("Unknown exception")

--- a/custom_components/veolia/config_flow.py
+++ b/custom_components/veolia/config_flow.py
@@ -50,7 +50,7 @@ class VeoliaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
                 None,
             )
-            if selected_commune["type_commune"] == "NON_REDIRIGE":
+            if selected_commune["type_commune"] in ("NON_REDIRIGE", "REDIRIGE"):
                 return await self.async_step_credentials()
 
             if selected_commune["type_commune"] == "NON_DESSERVIE":

--- a/custom_components/veolia/config_flow.py
+++ b/custom_components/veolia/config_flow.py
@@ -1,18 +1,15 @@
 """Config flow for veolia integration."""
 
-from urllib.parse import urlparse
-
 import aiohttp
 from veolia_api import VeoliaAPI
 from veolia_api.exceptions import VeoliaAPIInvalidCredentialsError
-from veolia_api.portals import VEOLIA_PORTAL_CLIENTS
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_PORTAL_URL, DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER
 
 
 class VeoliaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -26,7 +23,6 @@ class VeoliaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._errors = {}
         self._postal_code = None
         self._communes = []
-        self._portal_url: str | None = None
 
     async def async_step_user(self, user_input=None) -> dict:
         """Handle a flow initialized by the user."""
@@ -55,22 +51,13 @@ class VeoliaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 None,
             )
             if selected_commune["type_commune"] == "NON_REDIRIGE":
-                self._portal_url = None
                 return await self.async_step_credentials()
 
-            if selected_commune["type_commune"] == "REDIRIGE":
-                url_redirection = selected_commune.get("url_redirection", "")
-                hostname = urlparse(url_redirection).hostname or ""
-                if hostname in VEOLIA_PORTAL_CLIENTS:
-                    self._portal_url = hostname
-                    return await self.async_step_credentials()
-                self._errors["base"] = "commune_not_supported"
-            elif selected_commune["type_commune"] == "NON_DESSERVIE":
+            if selected_commune["type_commune"] == "NON_DESSERVIE":
                 self._errors["base"] = "commune_not_veolia"
             else:
                 self._errors["base"] = "commune_not_supported"
 
-        LOGGER.debug("Fetching communes for postal code %s", self._postal_code)
         async with (
             aiohttp.ClientSession() as session,
             session.get(
@@ -78,7 +65,6 @@ class VeoliaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             ) as response,
         ):
             self._communes = await response.json()
-            LOGGER.debug("Communes found: %s", self._communes)
 
         if not self._communes:
             self._errors["base"] = "no_communes_found"
@@ -102,14 +88,13 @@ class VeoliaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     user_input[CONF_USERNAME],
                     user_input[CONF_PASSWORD],
                     async_get_clientsession(self.hass),
-                    portal_url=self._portal_url,
                 )
                 valid = await api.login()
 
                 if valid:
                     return self.async_create_entry(
                         title=user_input[CONF_USERNAME],
-                        data={**user_input, CONF_PORTAL_URL: self._portal_url},
+                        data=user_input,
                     )
             except VeoliaAPIInvalidCredentialsError:
                 self._errors["base"] = "invalid_credentials"

--- a/custom_components/veolia/const.py
+++ b/custom_components/veolia/const.py
@@ -6,7 +6,6 @@ LOGGER: Logger = getLogger(__package__)
 
 DOMAIN = "veolia"
 NAME = "Veolia"
-CONF_PORTAL_URL = "portal_url"
 
 # Platforms
 SENSOR = "sensor"

--- a/custom_components/veolia/coordinator.py
+++ b/custom_components/veolia/coordinator.py
@@ -7,12 +7,12 @@ from typing import TYPE_CHECKING
 
 from dateutil.relativedelta import relativedelta
 from veolia_api import VeoliaAPI
-from veolia_api.exceptions import VeoliaAPIError
+from veolia_api.exceptions import VeoliaAPIError, VeoliaAPIInvalidCredentialsError
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, LOGGER
@@ -70,5 +70,7 @@ class VeoliaDataUpdateCoordinator(DataUpdateCoordinator):
             account_data = self.client_api.account_data
             today = dt_util.now().date()
             return VeoliaModel.from_account_data(account_data, today=today)
-        except VeoliaAPIError as exception:
+        except VeoliaAPIInvalidCredentialsError as exception:
             raise ConfigEntryAuthFailed(exception) from exception
+        except VeoliaAPIError as exception:
+            raise UpdateFailed(exception) from exception

--- a/custom_components/veolia/coordinator.py
+++ b/custom_components/veolia/coordinator.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_PORTAL_URL, DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER
 from .data import VeoliaConfigEntry
 from .model import VeoliaModel
 
@@ -45,7 +45,6 @@ class VeoliaDataUpdateCoordinator(DataUpdateCoordinator):
             username=self.config_entry.data[CONF_USERNAME],
             password=self.config_entry.data[CONF_PASSWORD],
             session=async_get_clientsession(hass),
-            portal_url=self.config_entry.data.get(CONF_PORTAL_URL),
         )
 
         self._initial_historical_fetch = False

--- a/custom_components/veolia/translations/en.json
+++ b/custom_components/veolia/translations/en.json
@@ -18,7 +18,7 @@
       },
       "credentials": {
         "title": "Credentials",
-        "description": "Good news, your Veolia account works with this integration. Please enter your Veolia login credentials:",
+        "description": "Good news, your Veolia account works with this integration. Please enter your login information that you use to log in to eau.veolia.fr :",
         "data": {
           "username": "Username",
           "password": "Password"

--- a/custom_components/veolia/translations/fr.json
+++ b/custom_components/veolia/translations/fr.json
@@ -18,7 +18,7 @@
       },
       "credentials": {
         "title": "Informations d'identification",
-        "description": "Bonne nouvelle, votre compte Veolia fonctionne avec cette intégration. Veuillez entrer vos informations de connexion Veolia :",
+        "description": "Bonne nouvelle votre compte Veolia fonctionne avec cette intégration. Veuillez entrer vos informations de connexion que vous utilisez pour vous connecter sur eau.veolia.fr :",
         "data": {
           "username": "Nom d'utilisateur",
           "password": "Mot de passe"


### PR DESCRIPTION
Les sites redirigés fonctionnent également avec les credentials de eau.veolia.fr qu'utilise [veolia-api](https://github.com/Jezza34000/veolia-api)
Dans le cadre eaudetm.monespace.eau.veolia.fr: REDIRIGE d'un point de vue portail web utilisateur, les données sont bien accessibles depuis veolia-api

Revert de la PR #101 

Couvre l'issue #100

la gestion du split des exceptions permet à HA de déterminer si c'est seulement une erreur de mot de passe (VeoliaAPIInvalidCredentialsError) ou autre erreur. 